### PR TITLE
fix(app): coingecko banner mobile overflow

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -188,7 +188,7 @@ function Layout({
           maxW="7xl"
           alignItems="center"
         >
-          <Flex overflow="hidden">
+          <Flex maxW="100%" overflow="hidden">
             {React.createElement('coingecko-coin-price-marquee-widget', {
               'coin-ids': 'defy,ethereum',
               currency: 'usd',

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -145,7 +145,10 @@ function Layout({
   return (
     <ChatWindow>
       <Helmet>
-        <script src="https://widgets.coingecko.com/coingecko-coin-price-marquee-widget.js"></script>
+        <script
+          async
+          src="https://widgets.coingecko.com/coingecko-coin-price-marquee-widget.js"
+        ></script>
       </Helmet>
 
       <Box mt={6}>
@@ -220,7 +223,10 @@ function Layout({
         {children}
 
         <Flex justifyContent={'center'}>
-          <script src="https://widgets.coingecko.com/coingecko-coin-price-chart-widget.js"></script>
+          <script
+            async
+            src="https://widgets.coingecko.com/coingecko-coin-price-chart-widget.js"
+          ></script>
           {React.createElement('coingecko-coin-price-chart-widget', {
             'coin-id': 'defy',
             currency: 'usd',


### PR DESCRIPTION
### Summary
- Fix for mobile layout issue where the coingecko banner extends past the width of the page.
- Load coingecko scripts asynchronously to prevent render blocking

### Result
<img width="413" alt="image" src="https://user-images.githubusercontent.com/88999537/214445845-42613e32-cfe8-4a9d-bb7e-514a18df2635.png">
